### PR TITLE
🛠️ Dev tooling: gitignore, hooks, Copilot docs, and title normalization CI

### DIFF
--- a/.githooks/commit-format.sh
+++ b/.githooks/commit-format.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Central commit message format definition.
+# Sourced (not executed) by every hook and the CI validation workflow so
+# that the allowed types and validation regex are defined in one place.
+#
+# Usage (in any POSIX sh script or CI step):
+#   REPO=$(git rev-parse --show-toplevel)
+#   . "$REPO/.githooks/commit-format.sh"
+#   # CC_TYPES and CC_PATTERN are now available.
+#
+# POSIX sh compliant — no bashisms.
+
+# ---------------------------------------------------------------------------
+# Pipe-separated list of allowed Conventional Commits types.
+# Used both in the validation regex and in human-readable error messages.
+# ---------------------------------------------------------------------------
+CC_TYPES='feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert'
+
+# ---------------------------------------------------------------------------
+# Full validation regex.
+# Requires:
+#   - At least one leading non-ASCII byte  (the emoji)
+#   - Followed by a space
+#   - Then a valid CC type from $CC_TYPES
+#   - Optional (scope), optional ! breaking-change marker
+#   - ": " separator
+#   - A non-empty description with no trailing whitespace
+#
+# Must be used with LC_ALL=C grep for byte-level matching:
+#   LC_ALL=C ensures [^ -~] covers all multi-byte UTF-8 sequences by
+#   matching any byte outside the printable ASCII range (0x20–0x7E).
+#
+# Example usage:
+#   printf '%s' "$msg" | LC_ALL=C grep -qE "$CC_PATTERN"
+# ---------------------------------------------------------------------------
+CC_PATTERN='^[^ -~][^ -~]* ('"$CC_TYPES"')(\([^)]+\))?(!)?: .*[^[:space:]]$'

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,38 @@
+#!/bin/sh
+# commit-msg hook — enforces Conventional Commits with a mandatory leading emoji.
+#
+# Format and allowed types are defined in .githooks/commit-format.sh.
+# Edit that file to change the validation rules everywhere at once.
+
+COMMIT_MSG_FILE="$1"
+
+# Load the central format definition (CC_TYPES, CC_PATTERN).
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+. "$REPO/.githooks/commit-format.sh"
+
+# Read the commit message, stripping comment lines and blank lines.
+FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^$' | head -1)
+
+# Allow empty messages (git handles this error itself).
+[ -z "$FIRST_LINE" ] && exit 0
+
+if ! printf '%s' "$FIRST_LINE" | LC_ALL=C grep -qE "$CC_PATTERN"; then
+  printf '\n' >&2
+  printf '❌  Commit rejected: message must start with an emoji and follow Conventional Commits format.\n' >&2
+  printf '\n' >&2
+  printf '    Required:  EMOJI <type>[(<scope>)][!]: <description>\n' >&2
+  printf '\n' >&2
+  printf '    Examples:\n' >&2
+  printf '      🎉 feat(acl): add server tag\n' >&2
+  printf '      🔒 fix(policy): restrict prod access\n' >&2
+  printf '      💥 chore!: drop legacy config\n' >&2
+  printf '      📝 docs: update setup instructions\n' >&2
+  printf '\n' >&2
+  printf '    Allowed types: %s\n' "$CC_TYPES" >&2
+  printf '\n' >&2
+  printf '    Your message: %s\n' "$FIRST_LINE" >&2
+  printf '\n' >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/commit-msg-fallback
+++ b/.githooks/commit-msg-fallback
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Fallback bootstrap — installed by 'make setup' into Git's common hooks dir.
+#
+# Purpose: if core.hooksPath is ever unset (e.g. after 'git worktree add',
+# a manual 'git config --unset core.hooksPath', or a fresh clone where
+# 'make setup' was not yet run), this script runs from the fallback path in
+# Git's common hooks dir and:
+#   1. Auto-reconfigures core.hooksPath to point at the versioned hooks.
+#   2. Delegates to the real commit-msg hook for format validation.
+#
+# Once this runs, future commits use .githooks/commit-msg directly (because
+# core.hooksPath is now set) and this file is no longer invoked.
+
+git config core.hooksPath .githooks || {
+  printf '⚠️  Could not configure core.hooksPath — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '⚠️  Could not determine repo root — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+exec "$REPO/.githooks/commit-msg" "$@"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,14 @@
+#!/bin/sh
+# post-checkout hook — re-configures core.hooksPath after every checkout so
+# that the versioned hooks in .githooks/ remain active after branch switches,
+# git pull --rebase, or any other operation that triggers a working-tree update.
+#
+# Git invokes this hook with three arguments:
+#   $1  previous HEAD (or zeros on initial checkout)
+#   $2  new HEAD
+#   $3  1 for branch checkout, 0 for file checkout
+# We act on all cases — re-configuring is idempotent and takes <1 ms.
+
+git config core.hooksPath .githooks || {
+  printf '⚠️  post-checkout: could not configure core.hooksPath — run "make setup" manually.\n' >&2
+}

--- a/.githooks/post-checkout-fallback
+++ b/.githooks/post-checkout-fallback
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Fallback bootstrap — installed by 'make setup' into the default Git hooks dir.
+#
+# Purpose: if core.hooksPath is unset in a clone or worktree, a checkout should
+# still restore the versioned hooks immediately.
+
+git config core.hooksPath .githooks || {
+  printf '⚠️  Could not configure core.hooksPath — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '⚠️  Could not determine repo root — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+exec "$REPO/.githooks/post-checkout" "$@"

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,53 @@
+#!/bin/sh
+# prepare-commit-msg hook — injects Conventional Commits format reminder as
+# comments so the required format is visible in the editor on every commit.
+#
+# Format and allowed types are defined in .githooks/commit-format.sh.
+# Skips injection for merge and squash commits (they already have content).
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="${2:-}"
+
+# Do not inject for merge/squash: those messages already carry meaning.
+case "$COMMIT_SOURCE" in
+  merge|squash) exit 0 ;;
+esac
+
+# If the message already has non-comment, non-blank content (e.g. -m flag or
+# --amend with existing subject), do not overwrite or append.
+if [ -s "$COMMIT_MSG_FILE" ]; then
+  CONTENT=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$')
+  if [ -n "$CONTENT" ]; then
+    exit 0
+  fi
+fi
+
+# Load the central format definition to get CC_TYPES for the hint.
+REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+. "$REPO/.githooks/commit-format.sh"
+
+# Convert pipe-separated types to space-separated for human-readable display.
+TYPES_DISPLAY=$(printf '%s' "$CC_TYPES" | tr '|' ' ')
+
+# Append the format reminder as Git comment lines (stripped before commit).
+{
+  printf '# ---------------------------------------------------------------------------\n'
+  printf '# Conventional Commits format (enforced by commit-msg hook and CI):\n'
+  printf '#\n'
+  printf '#   EMOJI <type>[(<scope>)][!]: <description>\n'
+  printf '#\n'
+  printf '#   ⚠️  A leading emoji is MANDATORY — the commit will be rejected without one.\n'
+  printf '#\n'
+  printf '# Allowed types:\n'
+  printf '#   %s\n' "$TYPES_DISPLAY"
+  printf '#\n'
+  printf '# Examples:\n'
+  printf '#   🎉 feat(acl): add new tag for servers\n'
+  printf '#   🔒 fix(policy): restrict access to prod\n'
+  printf '#   💥 chore!: drop legacy bootstrap config\n'
+  printf '#   📝 docs: update setup instructions\n'
+  printf '#   🚀 feat!: replace deny-all baseline with least-privilege policy\n'
+  printf '# ---------------------------------------------------------------------------\n'
+} >> "$COMMIT_MSG_FILE"
+
+exit 0

--- a/.githooks/prepare-commit-msg-fallback
+++ b/.githooks/prepare-commit-msg-fallback
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Fallback bootstrap — installed by 'make setup' into the default Git hooks dir.
+#
+# Purpose: if core.hooksPath is unset, this script restores it and then delegates
+# to the versioned prepare-commit-msg hook so commit message guidance still works.
+
+git config core.hooksPath .githooks || {
+  printf '⚠️  Could not configure core.hooksPath — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '⚠️  Could not determine repo root — run "make setup" manually.\n' >&2
+  exit 1
+}
+
+exec "$REPO/.githooks/prepare-commit-msg" "$@"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# GitHub Copilot Instructions
+
+## Commit message convention
+
+Every commit message in this repository **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification, with a **mandatory leading emoji**.
+
+### Format
+
+```
+EMOJI <type>[(<scope>)][!]: <description>
+```
+
+### Rules
+
+- The **emoji** is **mandatory**. It must be the first character and separated from the type by a single space.
+- The **type** is mandatory and must be one of:
+  `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
+- The **scope** is optional and written in parentheses: `(acl)`, `(policy)`, `(ci)`, etc.
+- The `!` suffix is optional and indicates a breaking change.
+- The **description** is mandatory, must follow the colon+space, and must not be empty or end with whitespace.
+- The first line must match the pattern.
+
+### Valid examples
+
+```
+🎉 feat(acl): add new tag for servers
+🔒 fix(policy): restrict access to prod
+💥 chore!: drop legacy bootstrap config
+📝 docs: update setup instructions
+🔧 ci(workflow): add policy lint step
+♻️ refactor(acl): split host aliases into groups
+🚀 feat!: replace deny-all baseline with least-privilege policy
+```
+
+### Invalid examples
+
+```
+feat(acl): add new tag for servers  ← missing emoji
+update stuff                        ← no type, no emoji
+WIP                                 ← no type, no emoji
+fix:                                ← missing emoji and description
+Added tag                           ← no type, no emoji
+feat : add tag                      ← space before colon, missing emoji
+```
+
+### Enforcement
+
+A `commit-msg` Git hook in `.githooks/` blocks any non-conforming commit locally.
+Activate it once after cloning with:
+
+```bash
+make setup
+```

--- a/.github/workflows/normalize-titles.yml
+++ b/.github/workflows/normalize-titles.yml
@@ -1,0 +1,148 @@
+name: Normalize Issue And PR Titles
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+jobs:
+  normalize:
+    name: Normalize title
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Normalize title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ccTypes = [
+              "feat",
+              "fix",
+              "docs",
+              "style",
+              "refactor",
+              "perf",
+              "test",
+              "chore",
+              "ci",
+              "build",
+              "revert",
+            ];
+
+            const emojiPoolByType = {
+              feat: ["✨", "🎉", "🚀", "💡", "🌟"],
+              fix: ["🩹", "🔒", "🐛", "🚑", "💊"],
+              docs: ["📝", "📖", "📚", "🗒️", "✍️"],
+              style: ["🎨", "💄", "✏️", "🖌️", "💅"],
+              refactor: ["♻️", "🔄", "🧱", "🏗️", "🔨"],
+              perf: ["⚡️", "🚀", "🏎️", "💨", "⏱️"],
+              test: ["✅", "🧪", "🔍", "🧬", "🎯"],
+              chore: ["🧹", "🔧", "🗑️", "📦", "🛠️"],
+              ci: ["🤖", "⚙️", "🔁", "🏭", "🔌"],
+              build: ["🏗️", "📦", "🔨", "🧱", "⚒️"],
+              revert: ["⏪", "↩️", "🔙", "♻️", "🔄"],
+            };
+
+            const randomEmoji = (type) => {
+              const pool = emojiPoolByType[type];
+              return pool[Math.floor(Math.random() * pool.length)];
+            };
+
+            const issue = context.payload.pull_request ?? context.payload.issue;
+            if (!issue) {
+              core.info("No issue or pull_request payload found; skipping.");
+              return;
+            }
+
+            const originalTitle = issue.title.trim();
+            if (!originalTitle) {
+              core.info("Empty title; skipping.");
+              return;
+            }
+
+            const exactPattern = new RegExp(
+              `^[^\\x20-\\x7E][^\\x20-\\x7E]* (${ccTypes.join("|")})(\\([^)]+\\))?(!)?: .*\\S$`,
+              "u",
+            );
+            if (exactPattern.test(originalTitle)) {
+              core.info(`Title already matches convention: "${originalTitle}"`);
+              return;
+            }
+
+            const lowerFirst = (value) =>
+              value.length === 0 ? value : value[0].toLowerCase() + value.slice(1);
+
+            const sentenceCase = (value) =>
+              value
+                .replace(/\s+/g, " ")
+                .trim()
+                .replace(/[.。!！?？]+$/u, "");
+
+            const guessType = (title) => {
+              const normalized = title.toLowerCase();
+              if (/\b(ci|workflow|github action|actions|pipeline)\b/.test(normalized)) return "ci";
+              if (/\b(build|release|bundle|compile|packag)\b/.test(normalized)) return "build";
+              if (/\b(test|spec|coverage)\b/.test(normalized)) return "test";
+              if (/\b(readme|doc|docs|documentation|guide)\b/.test(normalized)) return "docs";
+              if (/\b(refactor|cleanup|clean up|rename|reorganize)\b/.test(normalized)) return "refactor";
+              if (/\b(perf|performance|speed|faster|optimi[sz]e)\b/.test(normalized)) return "perf";
+              if (/\b(style|format|lint|prettier)\b/.test(normalized)) return "style";
+              if (/\b(fix|bug|error|issue|broken|hotfix|repair)\b/.test(normalized)) return "fix";
+              if (/\b(add|create|implement|introduce|support|enable|allow)\b/.test(normalized)) return "feat";
+              return "chore";
+            };
+
+            const plainCcPattern = new RegExp(
+              `^(${ccTypes.join("|")})(\\([^)]+\\))?(!)?:\\s+(.+?)\\s*$`,
+              "i",
+            );
+
+            const prefixedCcPattern = new RegExp(
+              `^[^\\w\\s]+\\s*(${ccTypes.join("|")})(\\([^)]+\\))?(!)?:\\s+(.+?)\\s*$`,
+              "iu",
+            );
+
+            let nextTitle;
+            const plainCcMatch = originalTitle.match(plainCcPattern);
+            if (plainCcMatch) {
+              const [, type, scope = "", bang = "", description] = plainCcMatch;
+              const normalizedType = type.toLowerCase();
+              nextTitle = `${randomEmoji(normalizedType)} ${normalizedType}${scope}${bang}: ${sentenceCase(description)}`;
+            } else {
+              const prefixedCcMatch = originalTitle.match(prefixedCcPattern);
+              if (prefixedCcMatch) {
+                const [, type, scope = "", bang = "", description] = prefixedCcMatch;
+                const normalizedType = type.toLowerCase();
+                nextTitle = `${randomEmoji(normalizedType)} ${normalizedType}${scope}${bang}: ${sentenceCase(description)}`;
+              } else {
+                const inferredType = guessType(originalTitle);
+                const description = lowerFirst(sentenceCase(originalTitle));
+                nextTitle = `${randomEmoji(inferredType)} ${inferredType}: ${description}`;
+              }
+            }
+
+            if (nextTitle === originalTitle) {
+              core.info("Normalization produced no change; skipping update.");
+              return;
+            }
+
+            core.info(`Updating title from "${originalTitle}" to "${nextTitle}"`);
+
+            if (context.payload.pull_request) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                title: nextTitle,
+              });
+            } else {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                title: nextTitle,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# macOS
+.DS_Store
+
+# Editor
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Test outputs
+*.report.txt
+
+# Worktrees
+.worktrees/
+
+# Personal plists
+*.plist
+
+# Claude Code internals
+.claude-flow/
+docs/superpowers/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: setup install check-hooks
+
+# ---------------------------------------------------------------------------
+# Auto-bootstrap: configure the versioned hooks path on every 'make' invocation
+# so that commit-msg and prepare-commit-msg hooks are always active without
+# requiring an explicit 'make setup' first.
+# The := assignment forces immediate evaluation at Makefile parse time, meaning
+# the git config command runs before any target — idempotent and transparent.
+# stderr is suppressed (2>/dev/null) to stay silent when invoked outside a git
+# repository (e.g. some CI runners that only mount the Makefile).
+# ---------------------------------------------------------------------------
+_ := $(shell git config core.hooksPath .githooks 2>/dev/null)
+
+setup: ## Explicitly install local Git hooks (also runs automatically on any 'make' invocation)
+	git config core.hooksPath .githooks
+	@set -e; \
+	HOOKS_DIR=$$(git rev-parse --git-common-dir)/hooks; \
+	mkdir -p "$$HOOKS_DIR"; \
+	install -m 755 .githooks/commit-msg-fallback "$$HOOKS_DIR/commit-msg"; \
+	install -m 755 .githooks/prepare-commit-msg-fallback "$$HOOKS_DIR/prepare-commit-msg"; \
+	install -m 755 .githooks/post-checkout-fallback "$$HOOKS_DIR/post-checkout"
+	@echo "✅  Git hooks installed. Conventional Commits will be enforced on every commit."
+
+install: setup ## Install Git hooks (alias for setup)
+
+check-hooks: ## Verify that the local Git hooks are active; exit 1 if not
+	@HOOKS_PATH=$$(git config core.hooksPath 2>/dev/null); \
+	if [ "$$HOOKS_PATH" = ".githooks" ]; then \
+	  echo "✅  Git hooks are active (core.hooksPath = .githooks)."; \
+	else \
+	  echo "⚠️  Git hooks are NOT active. Run 'make setup' or 'make install' to install them." >&2; \
+	  exit 1; \
+	fi
+
+check: check-hooks ## Check if Git hooks are active (alias for check-hooks)


### PR DESCRIPTION
## Summary

This PR sets up contributor workflow and light automation for the repo.

### Changes

- **`.gitignore`** — Ignores macOS junk, editor state, test outputs, and other local noise so commits stay clean.
- **Git hooks (via Makefile `setup` / `install`)** — `core.hooksPath` points at versioned `.githooks`; `commit-msg` enforces Conventional Commits with a leading emoji (see `.githooks/commit-format.sh`). Fallback hooks in the common Git hooks dir recover if `core.hooksPath` is unset.
- **Copilot instructions** — Documents the commit message convention for AI-assisted edits.
- **GitHub Actions** — `normalize-titles.yml` workflow to normalize issue and PR titles (consistent titling in the UI).

### How to verify locally

- `make check` (or `make check-hooks`) — confirms hooks path is `.githooks`.
- Try a commit with a non-conforming subject line; the hook should reject it.

### Note for reviewers

Pushing workflow files may require GitHub credentials with the `workflow` scope if you use HTTPS + OAuth.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly developer-workflow automation, but it introduces local git hooks that can block commits and a `pull_request_target` workflow with write permissions that auto-edits issue/PR titles, so misconfiguration could disrupt contributions or be a security footgun if changed later.
> 
> **Overview**
> Adds repo-wide commit message enforcement by introducing versioned git hooks in `.githooks/` (shared `commit-format.sh`, `commit-msg` validation requiring a leading emoji + Conventional Commits types, and `prepare-commit-msg` guidance), plus fallback hooks and a `post-checkout` hook to re-assert `core.hooksPath`.
> 
> Introduces a Makefile bootstrap (`setup`/`install` plus `check-hooks`) that configures `core.hooksPath` and installs fallback hooks into the common hooks directory. Adds a `.gitignore`, Copilot commit-convention instructions, and a GitHub Action (`normalize-titles.yml`) that auto-normalizes issue/PR titles into the same emoji+Conventional-Commit style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f48b38184c35a7944823239553d4cb6460e4c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated normalization of issue and pull request titles based on Conventional Commits standards

* **Documentation**
  * Added comprehensive commit message format guidelines and repository standards documentation

* **Chores**
  * Established Git hooks infrastructure to validate commit messages against Conventional Commits format
  * Introduced Makefile with setup and configuration targets for local Git hooks
  * Added .gitignore with common build and development exclusions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->