### PR TITLE
🔒 fix(lint): enable ShellCheck external sources (-x)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,7 @@ test: ## Run smoke tests
 
 lint: ## Run ShellCheck on all shell scripts
 	@echo "Running ShellCheck..."
-	@shellcheck -x -s bash $(SCRIPT)
-	@shellcheck -x -s bash tests/test_helpers.sh
-	@shellcheck -x -s bash tests/smoke.bats-like.sh
+	@shellcheck -x -s bash $(SCRIPT) tests/test_helpers.sh tests/smoke.bats-like.sh
 	@echo "ShellCheck passed."
 
 install: setup ## Install tm-exclusions to PREFIX (default: /usr/local/bin)

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ test: ## Run smoke tests
 
 lint: ## Run ShellCheck on all shell scripts
 	@echo "Running ShellCheck..."
-	@shellcheck -s bash $(SCRIPT)
-	@shellcheck -s bash tests/test_helpers.sh
-	@shellcheck -s bash tests/smoke.bats-like.sh
+	@shellcheck -x -s bash $(SCRIPT)
+	@shellcheck -x -s bash tests/test_helpers.sh
+	@shellcheck -x -s bash tests/smoke.bats-like.sh
 	@echo "ShellCheck passed."
 
 install: setup ## Install tm-exclusions to PREFIX (default: /usr/local/bin)


### PR DESCRIPTION
## Summary

ShellCheck 0.11+ reports SC1091 on `tests/smoke.bats-like.sh` because it sources `test_helpers.sh` via `SCRIPT_DIR`. The `# shellcheck source=` hint is only applied when external sources are enabled.

## Change

- Add `-x` to all `make lint` `shellcheck` invocations so sourced files are followed and lint stays green locally and in CI.

## Verification

- `make lint`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the `make lint` ShellCheck invocation to follow sourced files; no runtime or shipped script behavior changes.
> 
> **Overview**
> Updates `make lint` to run ShellCheck once with `-x` enabled so external sourced files (e.g., `tests/test_helpers.sh` from `tests/smoke.bats-like.sh`) are followed during linting, avoiding SC1091 failures and keeping local/CI lint green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40204b8de9c4a73d9dd406780e90fb3139ae9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell script linting configuration to provide more comprehensive validation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->