### PR TITLE
🏭 ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: chore
+      prefix: ci
       include: scope
     labels:
       - "📦 Type: Dependency"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,22 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Paris
+    target-branch: master
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - "📦 Type: Dependency"
+      - "🧩 Area: CI"
+      - "🤖 Source: Dependabot"
+      - "🧰 Ecosystem: github-actions"
+      - "⏱️ Effort: Small"
+      - "🔥 Priority: Low"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,9 +2,9 @@ name: ShellCheck
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds [Dependabot version updates](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) for the `github-actions` ecosystem only (this repo has no npm/gem/etc. manifests).

- Weekly schedule
- Scans `/` for workflow action pins (`actions/checkout`, `actions/github-script`, etc.)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes: updates workflow triggers and Dependabot commit prefix, with no production code impact.
> 
> **Overview**
> Adds/adjusts GitHub Actions Dependabot config to use a `ci` commit-message prefix (still targeting `master`) and keeps action updates grouped/limited.
> 
> Updates the `ShellCheck` and `Tests` GitHub workflows to trigger on `master` instead of `main` for both `push` and `pull_request` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a966f6b39c9cafac958bb114b827ee7025a138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Dependabot configuration to run weekly checks for GitHub Actions updates on the master branch.
  * Limits open Dependabot PRs to 2, groups action updates together, sets a commit-message prefix, and applies predefined labels to generated PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->