### PR TITLE
🤖 ci: stale bot for issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+# From actions/starter-workflows automation/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: This issue has been marked stale due to inactivity.
+          stale-pr-message: This pull request has been marked stale due to inactivity.
+          stale-issue-label: "🕰️ Automation: Stale issue"
+          stale-pr-label: "🕰️ Automation: Stale pull request"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: -1
           stale-issue-message: This issue has been marked stale due to inactivity.
           stale-pr-message: This pull request has been marked stale due to inactivity.
           stale-issue-label: "🕰️ Automation: Stale issue"


### PR DESCRIPTION
Adds scheduled `stale.yml` with project Automation stale labels.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk automation-only change that affects GitHub issue/PR labeling; potential impact is limited to repository triage if the schedule or thresholds are undesired.
> 
> **Overview**
> Adds a new GitHub Actions workflow `stale.yml` that runs daily to mark issues and pull requests as stale after 60 days of inactivity, applying custom *Automation: Stale* labels and posting a short stale message.
> 
> The workflow is configured to **never auto-close** items (`days-before-close: -1`) and uses `GITHUB_TOKEN` with `issues`/`pull-requests` write permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb192a7a05e47b89fc45071ec228dbf8c719d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->