### PR TITLE
📝 docs: AGENTS guidance + catalog-driven triage labels

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # sync-labels true can remove labels not listed in labeler.yml (Types, Priority, etc.)
+          sync-labels: false
 
   normalize-title:
     if: github.event_name == 'issues' || (github.event_name == 'pull_request_target' && github.event.action != 'synchronize')
@@ -157,3 +159,173 @@ jobs:
                 title: nextTitle,
               });
             }
+
+  classify-by-reference:
+    needs: [normalize-title]
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Apply labels from reference catalog
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const isPr = Boolean(context.payload.pull_request);
+            const issueNumber = isPr ? context.payload.pull_request.number : context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: item } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            const ref = isPr ? context.payload.pull_request.base.sha : context.sha;
+            const labelsDoc = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path: "docs/LABELS.md",
+              ref,
+            });
+            const decoded = Buffer.from(labelsDoc.data.content, "base64").toString("utf8");
+
+            const knownLabels = [];
+            for (const line of decoded.split("\n")) {
+              const tableMatch = line.match(/^\|\s*`([^`]+)`\s*\|/);
+              if (tableMatch) knownLabels.push(tableMatch[1]);
+            }
+
+            const findLabel = (prefix, value) => {
+              const needle = `${prefix}: ${value}`.toLowerCase();
+              return knownLabels.find((label) => label.toLowerCase().includes(needle));
+            };
+
+            const extractRulesJson = (markdown) => {
+              const startMarker = "<!-- label-rules:start -->";
+              const endMarker = "<!-- label-rules:end -->";
+              const start = markdown.indexOf(startMarker);
+              const end = markdown.indexOf(endMarker);
+              if (start === -1 || end === -1 || end <= start) {
+                throw new Error("Missing label rules markers in docs/LABELS.md");
+              }
+
+              const between = markdown.slice(start + startMarker.length, end);
+              const fenced = between.match(/```json\s*([\s\S]*?)\s*```/i);
+              const payload = fenced ? fenced[1] : between;
+              return payload.trim();
+            };
+
+            const compilePatterns = (patterns) => {
+              const regexes = [];
+              for (const pattern of patterns ?? []) {
+                try {
+                  regexes.push(new RegExp(pattern, "i"));
+                } catch (error) {
+                  core.warning(`Invalid regex ignored: ${pattern} (${error.message})`);
+                }
+              }
+              return regexes;
+            };
+
+            const lower = (v) => (v ?? "").toLowerCase();
+            let changedFiles = [];
+            if (isPr) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: issueNumber,
+                per_page: 100,
+              });
+              changedFiles = files.map((f) => f.filename.toLowerCase());
+            }
+
+            const pathText = changedFiles.join("\n");
+            const text = `${item.title ?? ""}\n${item.body ?? ""}\n${pathText}`.toLowerCase();
+            const hasAny = (patterns) => patterns.some((pattern) => pattern.test(text));
+
+            const rulesJson = extractRulesJson(decoded);
+            const rulesConfig = JSON.parse(rulesJson);
+            const groups = rulesConfig.groups ?? {};
+            const extras = rulesConfig.extras ?? [];
+
+            const evaluateGroup = (prefix, group) => {
+              if (!group || !Array.isArray(group.rules)) return [];
+
+              const hits = [];
+              for (const rule of group.rules) {
+                const regexes = compilePatterns(rule.patterns);
+                if (regexes.length > 0 && hasAny(regexes)) {
+                  const name = findLabel(prefix, rule.suffix);
+                  if (name) hits.push(name);
+                  if (group.match === "first") break;
+                }
+              }
+              return hits;
+            };
+
+            const evaluateExtra = (extra) => {
+              const label = extra?.label;
+              if (!label?.prefix || !label?.suffix) return null;
+
+              if (extra.when === "actor_contains") {
+                const needle = lower(extra.value);
+                if (!needle || !lower(context.actor).includes(needle)) return null;
+                return findLabel(label.prefix, label.suffix);
+              }
+
+              if (extra.when === "pr_path_matches") {
+                if (!isPr) return null;
+                const regexes = compilePatterns(extra.patterns);
+                if (regexes.length === 0 || !regexes.some((re) => re.test(pathText))) return null;
+                return findLabel(label.prefix, label.suffix);
+              }
+
+              if (extra.when === "text_matches") {
+                const regexes = compilePatterns(extra.patterns);
+                if (regexes.length === 0 || !regexes.some((re) => re.test(text))) return null;
+                return findLabel(label.prefix, label.suffix);
+              }
+
+              core.warning(`Unknown extra rule ignored: ${extra.when}`);
+              return null;
+            };
+
+            const matched = [];
+            for (const [prefix, group] of Object.entries(groups)) {
+              matched.push(...evaluateGroup(prefix, group));
+            }
+            for (const extra of extras) {
+              const maybeLabel = evaluateExtra(extra);
+              if (maybeLabel) matched.push(maybeLabel);
+            }
+
+            const unique = [...new Set(matched)];
+            if (unique.length === 0) {
+              core.info("No reference-backed labels matched.");
+              return;
+            }
+
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const have = new Set(current.map((l) => l.name));
+            const missing = unique.filter((name) => !have.has(name));
+            if (missing.length === 0) {
+              core.info(`All matching labels already present: ${unique.join(", ")}`);
+              return;
+            }
+
+            core.info(`Adding labels: ${missing.join(", ")}`);
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: missing,
+            });

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -162,7 +162,11 @@ jobs:
 
   classify-by-reference:
     needs: [normalize-title]
-    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    # When normalize-title is skipped (e.g. pull_request_target synchronize), still run
+    # classification; default `needs` would skip this job if the needed job was skipped.
+    if: |
+      (github.event_name == 'issues' || github.event_name == 'pull_request_target') &&
+      (needs.normalize-title.result == 'success' || needs.normalize-title.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -170,7 +174,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply labels from reference catalog
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const isPr = Boolean(context.payload.pull_request);

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -227,7 +227,7 @@ jobs:
               const regexes = [];
               for (const pattern of patterns ?? []) {
                 try {
-                  regexes.push(new RegExp(pattern, "i"));
+                  regexes.push(new RegExp(pattern, "im"));
                 } catch (error) {
                   core.warning(`Invalid regex ignored: ${pattern} (${error.message})`);
                 }
@@ -264,8 +264,10 @@ jobs:
                 const regexes = compilePatterns(rule.patterns);
                 if (regexes.length > 0 && hasAny(regexes)) {
                   const name = findLabel(prefix, rule.suffix);
-                  if (name) hits.push(name);
-                  if (group.match === "first") break;
+                  if (name) {
+                    hits.push(name);
+                    if (group.match === "first") break;
+                  }
                 }
               }
               return hits;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+This file provides guidance to AI agentic LLM CLI tools when working with code in this repository.
+
+## Project overview
+- `tm-exclusions` is a single-file Bash CLI (`tm_exclusions.sh`) for managing macOS Time Machine exclusions for regenerable developer data.
+- It is config-driven: built-in rules come from `config/default.conf`; user rules come from `~/.config/tm_exclusions/custom.conf`.
+- Behavior and docs must stay aligned: when implementation changes, update `README.md`, tests in `tests/`, and `docs/ARCHITECTURE.md` when architectural behavior changes.
+
+## Core development commands
+- Show available make targets:
+  - `make help`
+- Run all checks:
+  - `make check`
+- Lint shell scripts:
+  - `make lint`
+- Run smoke tests:
+  - `make test`
+- Run the smoke test script directly:
+  - `bash tests/smoke.bats-like.sh`
+- Install locally:
+  - `make install`
+- Uninstall:
+  - `make uninstall`
+- Run CLI without installing:
+  - `bash tm_exclusions.sh --help`
+  - `bash tm_exclusions.sh --dry-run`
+
+## Single-test / focused validation workflow
+- There is no native per-test selector in `tests/smoke.bats-like.sh` (it runs end-to-end smoke checks).
+- For focused validation of one behavior, run the CLI command for that behavior directly (example: `bash tm_exclusions.sh --lang fr --help`) and/or execute a small isolated scenario with a temporary `HOME`.
+
+## Architecture map (big picture)
+- Entrypoint: `main()` in `tm_exclusions.sh`.
+  - Pre-scans args for early language/quiet behavior.
+  - Parses args into mode (`apply`, `dry-run`, `report-only`, `uninstall`) or config subcommands (`--init`, `--add`, `--list`, `--edit`).
+  - Runs environment detection (`tmutil` availability, macOS check).
+  - Loads merged config.
+  - Applies static path processing, then dynamic pattern scanning.
+  - Generates and persists report to `~/.config/tm_exclusions/last_report.txt`.
+- Processing model:
+  - Static rules (`path`) are handled directly.
+  - Dynamic rules (`pattern`) are discovered with `find "$HOME" -maxdepth 6 -type d -name <pattern>`.
+  - Prune rules (`prune`) exclude directory trees from dynamic scanning only (they do not create Time Machine exclusions).
+- `tmutil` integration:
+  - All Time Machine operations are wrapped via `tm_is_excluded`, `tm_add_exclusion`, `tm_remove_exclusion`.
+  - On non-macOS or when `tmutil` is unavailable, wrappers simulate behavior so tests can run without mutating Time Machine state.
+- Idempotency:
+  - Apply mode checks existing exclusion status before adding.
+  - Uninstall mode safely removes matched exclusions and supports `--force` for paths that no longer exist.
+
+## Constraints and repo-specific rules
+- Bash compatibility target is Bash 3.2+ (stock macOS). Avoid Bash 4+ features.
+- Keep quoting strict and portable shell style consistent with current script.
+- Config file format is `type|target|reason`; supported types are `path`, `pattern`, `prune`.
+- Conventional Commits with leading emoji are enforced by local hooks in `.githooks/`.
+  - Ensure hooks are active via `make setup` (also auto-bootstrapped by the Makefile).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@ This file provides guidance to AI agentic LLM CLI tools when working with code i
 
 ## Project overview
 - `tm-exclusions` is a single-file Bash CLI (`tm_exclusions.sh`) for managing macOS Time Machine exclusions for regenerable developer data.
-- It is config-driven: built-in rules come from `config/default.conf`; user rules come from `~/.config/tm_exclusions/custom.conf`.
+- It is config-driven: built-in rules come from the resolved default config (`resolve_default_conf()` in `tm_exclusions.sh` — e.g. `config/default.conf` in a repo checkout, `.../share/tm-exclusions/default.conf` when installed, or `$TM_EXCLUSIONS_DEFAULT_CONF` when set); user rules come from `~/.config/tm_exclusions/custom.conf`.
 - Behavior and docs must stay aligned: when implementation changes, update `README.md`, tests in `tests/`, and `docs/ARCHITECTURE.md` when architectural behavior changes.
 
 ## Core development commands
-- Show available make targets:
+- Show available make targets and manage the dev environment:
   - `make help`
+  - `make setup`
+  - `make check-hooks`
 - Run all checks:
   - `make check`
 - Lint shell scripts:
@@ -41,7 +43,7 @@ This file provides guidance to AI agentic LLM CLI tools when working with code i
 - Processing model:
   - Static rules (`path`) are handled directly.
   - Dynamic rules (`pattern`) are discovered with `find "$HOME" -maxdepth 6 -type d -name <pattern>`.
-  - Prune rules (`prune`) exclude directory trees from dynamic scanning only (they do not create Time Machine exclusions).
+  - Prune rules (`prune`) do not create Time Machine exclusions. They only skip applying exclusions to dynamic matches whose paths fall under a prune prefix after discovery; `find` still walks from `$HOME` — these rules filter results afterward and do not limit which directories `find` visits.
 - `tmutil` integration:
   - All Time Machine operations are wrapped via `tm_is_excluded`, `tm_add_exclusion`, `tm_remove_exclusion`.
   - On non-macOS or when `tmutil` is unavailable, wrappers simulate behavior so tests can run without mutating Time Machine state.
@@ -52,6 +54,6 @@ This file provides guidance to AI agentic LLM CLI tools when working with code i
 ## Constraints and repo-specific rules
 - Bash compatibility target is Bash 3.2+ (stock macOS). Avoid Bash 4+ features.
 - Keep quoting strict and portable shell style consistent with current script.
-- Config file format is `type|target|reason`; supported types are `path`, `pattern`, `prune`.
+- Config file format is `type|target|reason`; supported types are `path`, `pattern`, `prune`. The `target` field supports leading `~` expansion to the user’s home directory.
 - Conventional Commits with leading emoji are enforced by local hooks in `.githooks/`.
   - Ensure hooks are active via `make setup` (also auto-bootstrapped by the Makefile).

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -6,6 +6,101 @@ Style: labels avec emoji.
 
 Total: `45` labels.
 
+## Auto-labeling
+
+- PRs: `actions/labeler` lit [`.github/labeler.yml`](../.github/labeler.yml) et ajoute **tous** les labels `🧩 Area:*` dont les globs matchent les fichiers modifiés. `sync-labels` est désactivé pour ne pas retirer les autres labels (Types, priorités, etc.) que le labeler ne connaît pas.
+- Issues et PRs: le job `classify-by-reference` charge le catalogue depuis ce fichier (`docs/LABELS.md`) et résout dynamiquement les labels (emoji inclus), sans noms codés en dur dans le workflow. Il ajoute autant de labels pertinents que nécessaire sur `Area`, `Type`, `Status`, `Effort`, `Source` et `Ecosystem`, sans supprimer les labels existants.
+
+## Classification Rules (machine-readable)
+
+Single source of truth for auto-labeling rules used by `.github/workflows/triage.yml`.
+
+Schema:
+- `groups.<Prefix>.match`: `any` (all matching rules) or `first` (first matching rule only)
+- `groups.<Prefix>.rules[]`: `{ "suffix", "patterns" }`
+- `extras[]`: additional conditional labels via `when` (`actor_contains`, `text_matches`, `pr_path_matches`)
+
+<!-- label-rules:start -->
+```json
+{
+  "version": 1,
+  "groups": {
+    "Area": {
+      "match": "any",
+      "rules": [
+        { "suffix": "CI", "patterns": ["\\.github\\b", "(^|/)workflows?/", "\\b(ci|pipeline|github actions?|actions/)\\b"] },
+        { "suffix": "Tests", "patterns": ["(^|/)tests?/", "\\b(test|spec|coverage|smoke|bats)\\b"] },
+        { "suffix": "Core", "patterns": ["\\btm_exclusions\\.sh\\b", "\\btm-exclusions\\b", "\\b(cli|runtime|shell script|bash script)\\b"] },
+        { "suffix": "Config", "patterns": ["(^|/)config/", "\\b(default\\.conf|configuration|settings?)\\b"] },
+        { "suffix": "Hooks", "patterns": ["\\.githooks", "\\bgithooks?\\b", "\\bpre-commit\\b", "\\bcommit-msg\\b"] },
+        { "suffix": "Docs", "patterns": ["(^|/)docs/", "\\breadme\\.md\\b", "\\bchangelog\\b", "\\bdocumentation\\b", "\\breadme\\b"] },
+        { "suffix": "Build", "patterns": ["\\bmakefile\\b", "\\bbuild\\b", "\\brelease\\b", "\\bpackag(e|ing)\\b", "\\binstall(ation)?\\b"] }
+      ]
+    },
+    "Type": {
+      "match": "any",
+      "rules": [
+        { "suffix": "Security", "patterns": ["\\b(security|vulnerabilit|cve|hardening|permission|privilege|sandbox)\\b"] },
+        { "suffix": "Bug", "patterns": ["\\b(bug|broken|regression|crash|doesn'?t work|does not work|error|hotfix|fix)\\b"] },
+        { "suffix": "Breaking Change", "patterns": ["\\b(breaking|incompatible|semver major|bc[!:])\\b"] },
+        { "suffix": "Feature", "patterns": ["\\b(feature|new mode|new option|implement support|user story)\\b"] },
+        { "suffix": "Enhancement", "patterns": ["\\b(enhancement|improvement|polish|incremental)\\b"] },
+        { "suffix": "Documentation", "patterns": ["\\b(documentation|doc update|readme|guide)\\b"] },
+        { "suffix": "Test", "patterns": ["\\b(test|tests|testing|spec|coverage|smoke test)\\b"] },
+        { "suffix": "Build", "patterns": ["\\b(build|packaging|installer|makefile|release pipeline)\\b"] },
+        { "suffix": "Dependency", "patterns": ["\\b(dependabot|dependency|renovate|bump(\\s+deps?)?)\\b"] },
+        { "suffix": "Performance", "patterns": ["\\b(performance|perf|slow|faster|optimi[sz]e|latency|speed)\\b"] },
+        { "suffix": "Refactor", "patterns": ["\\b(refactor|cleanup|reorganize|rename)\\b"] },
+        { "suffix": "Chore", "patterns": ["\\b(chore|maintenance|housekeeping|format|lint|prettier|whitespace)\\b"] },
+        { "suffix": "Question", "patterns": ["\\b(question|how (do|to|can)|is it possible|clarif)\\b", "\\?\\s*$"] }
+      ]
+    },
+    "Status": {
+      "match": "first",
+      "rules": [
+        { "suffix": "Blocked", "patterns": ["\\b(blocked|blocking|cannot proceed|dependency)\\b"] },
+        { "suffix": "Duplicate", "patterns": ["\\b(duplicate|already reported|same as)\\b"] },
+        { "suffix": "Fixed", "patterns": ["\\b(fixed|resolved|done)\\b"] },
+        { "suffix": "In Progress", "patterns": ["\\b(in progress|wip|working on)\\b"] },
+        { "suffix": "Invalid", "patterns": ["\\b(invalid|not reproducible|cannot reproduce)\\b"] },
+        { "suffix": "Needs Info", "patterns": ["\\b(needs info|more info|missing info|steps to reproduce)\\b"] },
+        { "suffix": "On Hold", "patterns": ["\\b(on hold|paused|deferred)\\b"] },
+        { "suffix": "Ready", "patterns": ["\\b(ready to merge|ready)\\b"] },
+        { "suffix": "Review Needed", "patterns": ["\\b(review needed|needs review|please review)\\b"] },
+        { "suffix": "Won't Fix", "patterns": ["\\b(won't fix|wont fix|not planned)\\b"] }
+      ]
+    },
+    "Effort": {
+      "match": "first",
+      "rules": [
+        { "suffix": "X-Large", "patterns": ["\\b(x-large|xl|extra large|multiple weeks)\\b"] },
+        { "suffix": "Large", "patterns": ["\\b(large|big|significant|about a week)\\b"] },
+        { "suffix": "Medium", "patterns": ["\\b(medium|moderate|few days)\\b"] },
+        { "suffix": "Small", "patterns": ["\\b(small|quick fix|few hours|minor)\\b"] }
+      ]
+    }
+  },
+  "extras": [
+    {
+      "when": "actor_contains",
+      "value": "dependabot",
+      "label": { "prefix": "Source", "suffix": "Dependabot" }
+    },
+    {
+      "when": "pr_path_matches",
+      "patterns": ["\\.github/workflows/"],
+      "label": { "prefix": "Ecosystem", "suffix": "github-actions" }
+    },
+    {
+      "when": "text_matches",
+      "patterns": ["\\b(github actions?|actions/)\\b"],
+      "label": { "prefix": "Ecosystem", "suffix": "github-actions" }
+    }
+  ]
+}
+```
+<!-- label-rules:end -->
+
 ## Types
 
 | Label | Couleur | Description | Usage / Exemple |


### PR DESCRIPTION
## Summary
Adds `AGENTS.md` so agentic CLI tools have repo-specific commands, constraints, and an architecture map. Extends triage so issues and PRs can pick up **Type**, **Area**, **Status**, **Effort**, **Source**, and **Ecosystem** labels from the same catalog as `docs/LABELS.md`, without hard-coding label strings in the workflow. Disables `actions/labeler` `sync-labels` so Area globs do not strip unrelated labels.

## Changes
1. **AGENTS.md** — developer commands (`make` targets), static vs dynamic rules, `tmutil` behavior, Bash 3.2 constraints, and doc/test alignment expectations.
2. **Triage** — new `classify-by-reference` job (`actions/github-script`) loads `docs/LABELS.md` at the base ref, parses the JSON between `label-rules` markers, matches title/body (and PR changed files for path rules), and adds missing labels only.
3. **docs/LABELS.md** — auto-labeling notes, machine-readable rules block, and a repo-relative link to `.github/labeler.yml`.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

🤖 Generated with Cursor Agent (via Cursor IDE)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes GitHub Actions triage automation (label application and workflow behavior) for issues/PRs; failures could mislabel or error on missing/invalid `docs/LABELS.md` rule markers but does not affect runtime code.
> 
> **Overview**
> Updates the triage workflow so `actions/labeler` no longer *removes* non-`Area` labels (`sync-labels: false`).
> 
> Adds a new `classify-by-reference` GitHub Actions job that reads `docs/LABELS.md` at the PR base ref, parses machine-readable JSON rules, matches them against issue/PR title/body (and PR changed paths), and **adds** any missing `Area`/`Type`/`Status`/`Effort`/`Source`/`Ecosystem` labels without deleting existing ones.
> 
> Introduces `AGENTS.md` and extends `docs/LABELS.md` with auto-labeling documentation plus the embedded rule block used by the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28488d84b46b126eee69838d62ef2e8614bb98e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->