### PR TITLE
🔧 chore: bump VERSION to 1.1.0

### DIFF
--- a/tests/smoke.bats-like.sh
+++ b/tests/smoke.bats-like.sh
@@ -63,7 +63,7 @@ assert_output_contains "tm-exclusions" \
     "--version shows program name" \
     bash "$TM_EXCLUSIONS" --version
 
-assert_output_contains "1.0.0" \
+assert_output_contains "1.1.0" \
     "--version shows version number" \
     bash "$TM_EXCLUSIONS" --version
 

--- a/tm_exclusions.sh
+++ b/tm_exclusions.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-readonly VERSION="1.0.0"
+readonly VERSION="1.1.0"
 readonly PROGRAM_NAME="tm-exclusions"
 readonly CUSTOM_CONF="${HOME}/.config/tm_exclusions/custom.conf"
 readonly REPORT_FILE="${HOME}/.config/tm_exclusions/last_report.txt"


### PR DESCRIPTION
Prepare **v1.1.0** embedded version and smoke assertion. Changelog lands in a follow-up **release/v1.1.0** PR (squash-only repo).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a version constant and a smoke-test assertion, with no behavior or data-flow impact.
> 
> **Overview**
> Updates `tm_exclusions.sh` to report version `1.1.0` via `--version`, and adjusts `tests/smoke.bats-like.sh` to assert the new version string in the version output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce1f1945b69ad7feccdef58104456785fe254b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->