### PR TITLE
🔖 chore(release): v1.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+
+### CLI
+
+- Embedded version **1.1.0** (`tm-exclusions --version`).
+
+### CI and automation
+
+- PR triage workflow: apply labels from `docs/LABELS.md` (Area, Type, Status, Priority, Effort, extras); Priority labels are mutually exclusive when multiple match.
+- Label catalog reference in-repo (`docs/LABELS.md`) with JSON rules for triage.
+- Dependabot for GitHub Actions; consolidated lint + smoke workflow; PR labeler and title normalization; stale bot; dependency review and CodeQL for Actions.
+
+### Docs
+
+- `AGENTS.md` guidance for agentic tools; expanded GitHub label reference.
+
 ## v1.0.0
 
 - Initial stable release.


### PR DESCRIPTION
Adds **CHANGELOG** section for **v1.1.0**. Version bump is already on `master` (#32).

Squash-merge this PR so `create_release_tag.sh` with `RELEASE_TAG_ON_MASTER=1` can tag the resulting changelog-only commit.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change to `CHANGELOG.md` with no runtime or configuration impact.
> 
> **Overview**
> Documents the `v1.1.0` release in `CHANGELOG.md`, including the embedded CLI version bump and notable CI/automation and documentation updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc364f0d15406c9eea2fceb048591a82d3f725bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->