### PR TITLE
🤖 ci: 📦 Axis A: Homebrew, release CI, docs (#24–#29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+# On tag v*, create/update GitHub Release and bump Formula/tm-exclusions.rb in qveys/homebrew-tools.
+# Repository secret: HOMEBREW_TAP_TOKEN — PAT with repo scope on qveys/homebrew-tools
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "tm-exclusions $TAG"
+          else
+            gh release create "$TAG" --title "tm-exclusions $TAG" --generate-notes
+          fi
+
+      - name: Compute tarball SHA256
+        id: sha256
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          curl --fail --retry 5 --retry-delay 3 -sSL "$URL" -o release.tar.gz
+          SHA256="$(sha256sum release.tar.gz | awk '{print $1}')"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          URL: ${{ steps.sha256.outputs.url }}
+          SHA256: ${{ steps.sha256.outputs.sha256 }}
+        run: |
+          if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set; skipping tap bump."
+            exit 0
+          fi
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/qveys/homebrew-tools.git" tap
+          cd tap
+          test -f Formula/tm-exclusions.rb || { echo "ERROR: Formula/tm-exclusions.rb missing in tap"; exit 1; }
+          sed -i "s|^  url \".*\"|  url \"${URL}\"|" Formula/tm-exclusions.rb
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" Formula/tm-exclusions.rb
+          sed -i "s|^  version \".*\"|  version \"${VERSION}\"|" Formula/tm-exclusions.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/tm-exclusions.rb
+          git diff --staged --quiet && echo "No formula changes" && exit 0
+          git commit -m "Update tm-exclusions to ${TAG}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version
         id: version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@ This file provides guidance to AI agentic LLM CLI tools when working with code i
 - It is config-driven: built-in rules come from the resolved default config (`resolve_default_conf()` in `tm_exclusions.sh` — e.g. `config/default.conf` in a repo checkout, `.../share/tm-exclusions/default.conf` when installed, or `$TM_EXCLUSIONS_DEFAULT_CONF` when set); user rules come from `~/.config/tm_exclusions/custom.conf`.
 - Behavior and docs must stay aligned: when implementation changes, update `README.md`, tests in `tests/`, and `docs/ARCHITECTURE.md` when architectural behavior changes.
 
+## Maintainer docs
+- **`docs/PACKAGING.md`** — `make install` vs Homebrew, tap release automation.
+- **`docs/I18N.md`** — embedded English/French strings (vs archived `locales/`).
+- **`docs/DEV_TOOLING.md`** — `.cursor` / `AGENTS.md` vs archived `.claude/`.
+- Root **`CLAUDE.md`** — stub for Claude Code; points here.
+
 ## Core development commands
 - Show available make targets and manage the dev environment:
   - `make help`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code
+
+Instructions for working in **this** repository (`tm-exclusions`) are maintained in **`AGENTS.md`**.
+
+Open **`AGENTS.md`** first for commands, architecture, and constraints (Bash 3.2, config model, tests).
+
+For packaging and Homebrew, see **`docs/PACKAGING.md`**.

--- a/Formula/tm-exclusions.rb
+++ b/Formula/tm-exclusions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Homebrew formula aligned with the Makefile install layout:
+#   bin/tm-exclusions          (from tm_exclusions.sh)
+#   share/tm-exclusions/default.conf
+# Same paths as `make install` with PREFIX=.../Cellar/.../VERSION (Homebrew prefix).
+#
+# Official tap updates (url, sha256, version) on each release tag via
+# `.github/workflows/release.yml` and `qveys/homebrew-tools` — keep `install` in sync here and in the tap.
+class TmExclusions < Formula
+  desc "Time Machine exclusion manager for developer Macs"
+  homepage "https://github.com/qveys/tm-exclusions"
+  url "https://github.com/qveys/tm-exclusions/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "93d9f89e76f0b4c645340a1191d3d77d12a3156e0cbbd496a998d4c587b1cee2"
+  license "MIT"
+  version "1.1.0"
+
+  depends_on :macos
+
+  def install
+    bin.install "tm_exclusions.sh" => "tm-exclusions"
+    (share/"tm-exclusions").install "config/default.conf"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tm-exclusions --version")
+    assert_path_exists share/"tm-exclusions/default.conf"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ make install
 After the formula is published in [qveys/homebrew-tools](https://github.com/qveys/homebrew-tools) (updated automatically on each **`v*`** tag when `HOMEBREW_TAP_TOKEN` is configured):
 
 ```bash
-brew tap qveys/homebrew-tools
+brew tap qveys/tools
 brew install tm-exclusions
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ cd tm-exclusions
 make install
 ```
 
+### Homebrew
+
+After the formula is published in [qveys/homebrew-tools](https://github.com/qveys/homebrew-tools) (updated automatically on each **`v*`** tag when `HOMEBREW_TAP_TOKEN` is configured):
+
+```bash
+brew tap qveys/homebrew-tools
+brew install tm-exclusions
+```
+
+From a git checkout you can install the local formula (macOS):
+
+```bash
+brew install --formula ./Formula/tm-exclusions.rb
+```
+
+See **`docs/PACKAGING.md`** for Makefile vs Homebrew layout and tap sync.
+
 Or run directly without installing:
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ main()
 ## Config Merge Order
 
 Configuration is loaded and merged in this order:
-1. **Default rules** — resolved by `resolve_default_conf()`: repo-relative `config/default.conf`, `../share/tm-exclusions/default.conf` beside the installed binary, fixed paths under `/usr/local` / `/opt/homebrew` / `/usr/share`, or **`TM_EXCLUSIONS_DEFAULT_CONF`** when set (absolute path to a rules file).
+1. **Default rules** — resolved by `resolve_default_conf()`: if **`TM_EXCLUSIONS_DEFAULT_CONF`** is set, its value is used as the rules file path and resolution stops (absolute path recommended; relative paths are passed through as-is). Otherwise, fallback checks in order: repo-relative `config/default.conf`, `../share/tm-exclusions/default.conf` beside the installed binary, `/usr/local/share/tm-exclusions/default.conf`, `/opt/homebrew/share/tm-exclusions/default.conf`, `/usr/share/tm-exclusions/default.conf`.
 2. `~/.config/tm_exclusions/custom.conf` — user-defined rules
 
 Strings for **en** / **fr** are embedded in `tm_exclusions.sh` (not external locale files); see **`docs/I18N.md`**.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,8 +24,10 @@ main()
 ## Config Merge Order
 
 Configuration is loaded and merged in this order:
-1. `config/default.conf` — built-in rules shipped with the tool
+1. **Default rules** — resolved by `resolve_default_conf()`: repo-relative `config/default.conf`, `../share/tm-exclusions/default.conf` beside the installed binary, fixed paths under `/usr/local` / `/opt/homebrew` / `/usr/share`, or **`TM_EXCLUSIONS_DEFAULT_CONF`** when set (absolute path to a rules file).
 2. `~/.config/tm_exclusions/custom.conf` — user-defined rules
+
+Strings for **en** / **fr** are embedded in `tm_exclusions.sh` (not external locale files); see **`docs/I18N.md`**.
 
 Later entries are appended; there is no override or deduplication. Both files use the same `type|target|reason` format.
 

--- a/docs/DEV_TOOLING.md
+++ b/docs/DEV_TOOLING.md
@@ -1,0 +1,28 @@
+# Developer tooling: `.cursor` vs archived `.claude`
+
+This document compares what ships in **tm-exclusions** today versus the **archived** `tm-exclusion-main` tree (`~/Downloads/tm-exclusion-main`).
+
+## This repository (Cursor-first)
+
+| Area | Location | Role |
+|------|----------|------|
+| Agent instructions | `AGENTS.md` | Primary doc for AI CLI tools (Cursor, Claude Code, etc.) |
+| Cursor rules / skills | `.cursor/skills/` | Repo-local skills (e.g. release orchestration, git cleanup) |
+| Hooks | `.githooks/` + `Makefile` `setup` | Conventional Commits, hook fallbacks |
+| CI | `.github/workflows/` | Lint, smoke, security, triage, **release** (tag → tap bump) |
+
+There is **no** `.claude/` directory in this repo. Claude Code is expected to read **`AGENTS.md`** (and root **`CLAUDE.md`**, which points here).
+
+## Archived layout (reference)
+
+The archive included **`.claude/`** (project hooks, commands, settings) and a root **`CLAUDE.md`** tailored to that layout. That content is **not** copied verbatim: this project standardized on **`AGENTS.md`** + **`.cursor/skills/`** for agent UX.
+
+## When to add `.claude/`
+
+Optional if you want Claude Code–specific slash commands or settings that do not belong in `AGENTS.md`. Prefer keeping **one** canonical doc (`AGENTS.md`) and small pointers in `CLAUDE.md` to avoid drift.
+
+## Audit checklist (occasional)
+
+- [ ] `AGENTS.md` still lists accurate `make` targets and script entrypoints.
+- [ ] `.cursor/skills/*` frontmatter paths still resolve from repo root.
+- [ ] No duplicate/conflicting guidance between `CLAUDE.md` and `AGENTS.md`.

--- a/docs/DEV_TOOLING.md
+++ b/docs/DEV_TOOLING.md
@@ -1,6 +1,6 @@
 # Developer tooling: `.cursor` vs archived `.claude`
 
-This document compares what ships in **tm-exclusions** today versus the **archived** `tm-exclusion-main` tree (`~/Downloads/tm-exclusion-main`).
+This document compares what ships in **tm-exclusions** today versus an **archived** `tm-exclusion-main` tree (legacy tarball or checkout you keep locally — not part of this repo).
 
 ## This repository (Cursor-first)
 

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -2,7 +2,7 @@
 
 ## Current design (1.x)
 
-All user-visible strings for **English** and **French** live **inside** `tm_exclusions.sh` as functions `declare_i18n_en` and `declare_i18n_fr`. The active set is selected at runtime from `--lang` or from `LANG` / `LC_*` (see `detect_language()`).
+All user-visible strings for **English** and **French** live **inside** `tm_exclusions.sh` as functions `declare_i18n_en` and `declare_i18n_fr`. The active set is selected at runtime from `--lang` or, if unset, from locale env vars in `detect_language()` order: `LC_ALL`, `LC_MESSAGES`, `LC_CTYPE`, then `LANG`.
 
 There are **no** external `locales/*.sh` files in this repository.
 
@@ -24,7 +24,7 @@ There are **no** external `locales/*.sh` files in this repository.
 
 ## Archived 2.x layout (reference only)
 
-The tarball under `~/Downloads/tm-exclusion-main` used **`locales/en.sh`** and **`locales/fr.sh`** sourced by the main script. That split is **not** implemented in 1.x.
+The archived **2.x** layout used **`locales/en.sh`** and **`locales/fr.sh`** sourced by the main script. That split is **not** implemented in 1.x.
 
 ## Epic #34
 

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,31 @@
+# Internationalization (i18n)
+
+## Current design (1.x)
+
+All user-visible strings for **English** and **French** live **inside** `tm_exclusions.sh` as functions `declare_i18n_en` and `declare_i18n_fr`. The active set is selected at runtime from `--lang` or from `LANG` / `LC_*` (see `detect_language()`).
+
+There are **no** external `locales/*.sh` files in this repository.
+
+### Why embedded?
+
+- Single file to install (`make install` / Homebrew `bin.install`).
+- No path resolution for locale bundles beyond the script itself.
+- Bash 3.2–compatible without extra sourcing machinery.
+
+### Adding or changing strings
+
+1. Add the key in **both** `declare_i18n_en` and `declare_i18n_fr`.
+2. Run `make check` and spot-check `bash tm_exclusions.sh --lang fr --help` (and `en`).
+3. Update `README.md` if user-facing docs quote fixed English text.
+
+### Optional override
+
+`TM_EXCLUSIONS_DEFAULT_CONF` overrides the built-in rules file only; it does not change i18n. There is no `TM_EXCLUSIONS_LANG_DIR` today.
+
+## Archived 2.x layout (reference only)
+
+The tarball under `~/Downloads/tm-exclusion-main` used **`locales/en.sh`** and **`locales/fr.sh`** sourced by the main script. That split is **not** implemented in 1.x.
+
+## Epic #34
+
+Functional parity work (sudo/`-p`, richer reports, extra scans, etc.) is tracked in GitHub **#34**. If future parity reintroduces **external** locale files, document the new layout here and in `docs/PACKAGING.md`.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,45 @@
+# Packaging and distribution
+
+## Makefile install (source checkout)
+
+Default layout (see `Makefile`):
+
+| Artifact | Path |
+|----------|------|
+| CLI | `$(PREFIX)/tm-exclusions` (default `PREFIX=/usr/local/bin`) |
+| Built-in rules | `$(SHARE_DIR)/default.conf` with `SHARE_DIR` = `$(abspath $(PREFIX)/../share/tm-exclusions)` |
+
+`tm_exclusions.sh` resolves `config/default.conf` via `resolve_default_conf()` (repo checkout, `../share/tm-exclusions/default.conf` next to the binary, or standard `/usr/local` / `/opt/homebrew` share paths).
+
+## Homebrew
+
+### From this repository (development)
+
+On macOS, with [Homebrew](https://brew.sh/) installed:
+
+```bash
+brew install --formula ./Formula/tm-exclusions.rb
+```
+
+Bump `url`, `version`, and `sha256` in `Formula/tm-exclusions.rb` when cutting a new tag (or let the tap automation below handle the tap copy).
+
+### From the tap (`qveys/homebrew-tools`)
+
+After a **`v*`** tag is pushed, `.github/workflows/release.yml` (if enabled) creates/updates the GitHub release and bumps **`Formula/tm-exclusions.rb`** in **`qveys/homebrew-tools`** using repository secret **`HOMEBREW_TAP_TOKEN`** (PAT with `repo` on the tap).
+
+Then:
+
+```bash
+brew tap qveys/homebrew-tools
+brew install tm-exclusions
+```
+
+(Confirm the tap name in [qveys/homebrew-tools](https://github.com/qveys/homebrew-tools) if it differs.)
+
+### Tap formula sync
+
+The `install` stanza in the tap **must** match this repo’s `Formula/tm-exclusions.rb` (`bin.install` + `share/tm-exclusions`). The release job only rewrites `url`, `sha256`, and `version` lines; if the install layout changes, update both places (or replace the tap file from this repo once).
+
+## Relationship to epic #34
+
+Homebrew ships the **current 1.x** CLI. Broader behavior parity with the archived 2.x script is tracked in GitHub issue **#34**; packaging does not wait on that epic, but version bumps should stay consistent across `tm_exclusions.sh` `VERSION`, `CHANGELOG.md`, and the formula.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -9,7 +9,7 @@ Default layout (see `Makefile`):
 | CLI | `$(PREFIX)/tm-exclusions` (default `PREFIX=/usr/local/bin`) |
 | Built-in rules | `$(SHARE_DIR)/default.conf` with `SHARE_DIR` = `$(abspath $(PREFIX)/../share/tm-exclusions)` |
 
-`tm_exclusions.sh` resolves `config/default.conf` via `resolve_default_conf()` (repo checkout, `../share/tm-exclusions/default.conf` next to the binary, or standard `/usr/local` / `/opt/homebrew` share paths).
+`tm_exclusions.sh` resolves the default rules via `resolve_default_conf()`: optional **`TM_EXCLUSIONS_DEFAULT_CONF`** override first; else `config/default.conf` (repo), `../share/tm-exclusions/default.conf` (next to the binary), then `/usr/local/share/tm-exclusions/default.conf`, `/opt/homebrew/share/tm-exclusions/default.conf`, and `/usr/share/tm-exclusions/default.conf`.
 
 ## Homebrew
 
@@ -25,12 +25,12 @@ Bump `url`, `version`, and `sha256` in `Formula/tm-exclusions.rb` when cutting a
 
 ### From the tap (`qveys/homebrew-tools`)
 
-After a **`v*`** tag is pushed, `.github/workflows/release.yml` (if enabled) creates/updates the GitHub release and bumps **`Formula/tm-exclusions.rb`** in **`qveys/homebrew-tools`** using repository secret **`HOMEBREW_TAP_TOKEN`** (PAT with `repo` on the tap).
+After a **`v*`** tag is pushed, `.github/workflows/release.yml` (if enabled) creates/updates the GitHub Release and bumps **`Formula/tm-exclusions.rb`** in **`qveys/homebrew-tools`** using repository secret **`HOMEBREW_TAP_TOKEN`** (PAT with `repo` on the tap).
 
 Then:
 
 ```bash
-brew tap qveys/homebrew-tools
+brew tap qveys/tools
 brew install tm-exclusions
 ```
 

--- a/tests/smoke.bats-like.sh
+++ b/tests/smoke.bats-like.sh
@@ -202,5 +202,31 @@ assert_exit_code 1 \
     "--add with missing args exits 1" \
     bash "$TM_EXCLUSIONS" --add path
 
+# ---- TM_EXCLUSIONS_DEFAULT_CONF (install-style override) ----
+echo ""
+echo "--- TM_EXCLUSIONS_DEFAULT_CONF ---"
+
+MINIMAL_CONF="${TEST_HOME}/minimal-default.conf"
+cat > "${MINIMAL_CONF}" << 'EOF'
+# minimal default for smoke
+path|/tmp/tm_exclusions_smoke_path|smoke test path
+EOF
+
+assert_exit_code 0 \
+    "TM_EXCLUSIONS_DEFAULT_CONF dry-run exits 0" \
+    env TM_EXCLUSIONS_DEFAULT_CONF="${MINIMAL_CONF}" bash "$TM_EXCLUSIONS" --dry-run
+
+assert_output_contains "/tmp/tm_exclusions_smoke_path" \
+    "TM_EXCLUSIONS_DEFAULT_CONF dry-run uses override file" \
+    env TM_EXCLUSIONS_DEFAULT_CONF="${MINIMAL_CONF}" bash "$TM_EXCLUSIONS" --dry-run
+
+# ---- Parity harness (#34) ----
+echo ""
+echo "--- Parity placeholders (epic #34) ---"
+
+assert_output_contains "tm-exclusions" \
+    "--version stable for packaging smoke" \
+    bash "$TM_EXCLUSIONS" --version
+
 # ---- Summary ----
 test_summary

--- a/tests/smoke.bats-like.sh
+++ b/tests/smoke.bats-like.sh
@@ -123,6 +123,10 @@ assert_output_contains "Usage:" \
     "--lang en shows English help" \
     bash "$TM_EXCLUSIONS" --lang en --help
 
+assert_output_contains "Utilisation" \
+    "LC_MESSAGES=fr_FR.UTF-8 shows French help (detect_language)" \
+    env LC_ALL= LC_MESSAGES=fr_FR.UTF-8 LANG=C bash "$TM_EXCLUSIONS" --help
+
 assert_exit_code 1 \
     "--lang rejects unsupported values" \
     bash "$TM_EXCLUSIONS" --lang de --help

--- a/tm_exclusions.sh
+++ b/tm_exclusions.sh
@@ -209,12 +209,25 @@ resolve_default_conf() {
 
 # Detect language from environment or override
 detect_language() {
+    local loc=""
+
     if [[ -n "${LANG_OVERRIDE}" ]]; then
         CURRENT_LANG="${LANG_OVERRIDE}"
-    elif [[ "${LANG:-}" == fr* ]]; then
-        CURRENT_LANG="fr"
     else
-        CURRENT_LANG="en"
+        if [[ -n "${LC_ALL:-}" ]]; then
+            loc="${LC_ALL}"
+        elif [[ -n "${LC_MESSAGES:-}" ]]; then
+            loc="${LC_MESSAGES}"
+        elif [[ -n "${LC_CTYPE:-}" ]]; then
+            loc="${LC_CTYPE}"
+        elif [[ -n "${LANG:-}" ]]; then
+            loc="${LANG}"
+        fi
+        if [[ "${loc}" == fr* ]]; then
+            CURRENT_LANG="fr"
+        else
+            CURRENT_LANG="en"
+        fi
     fi
 
     case "${CURRENT_LANG}" in


### PR DESCRIPTION
## Summary

Grouped PR for **axis A** (distribution & repo governance) from the gap plan vs `tm-exclusion-main` — **does not** implement CLI parity (**#34**).

### Commits (one per issue)

| Issue | Change |
|-------|--------|
| **#24** | `Formula/tm-exclusions.rb`, `docs/PACKAGING.md`, README Homebrew |
| **#25** | `.github/workflows/release.yml` (tag → release + tap bump with `HOMEBREW_TAP_TOKEN`) |
| **#26** | `docs/I18N.md`, `docs/ARCHITECTURE.md` (default conf + i18n pointer) |
| **#27** | `CLAUDE.md` stub → `AGENTS.md` |
| **#28** | `docs/DEV_TOOLING.md`, `AGENTS.md` maintainer index |
| **#29** | Smoke: `TM_EXCLUSIONS_DEFAULT_CONF`, #34 placeholder |

### Follow-ups

- Configure **`HOMEBREW_TAP_TOKEN`** on the repo for tap automation.
- Align tap formula `install` with this repo if the tap still uses the old libexec layout.

Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds tag-triggered release automation that pushes commits to an external Homebrew tap using a PAT, so misconfiguration could publish incorrect formula metadata. Runtime behavior changes are small (locale detection + default-config override smoke coverage) but touch user-facing output selection.
> 
> **Overview**
> Adds an automated **release pipeline**: pushing a `v*` tag now creates/updates a GitHub Release, computes the source tarball SHA256, and (when `HOMEBREW_TAP_TOKEN` is set) updates `qveys/homebrew-tools` by rewriting the formula’s `url`/`sha256`/`version` and pushing a commit.
> 
> Introduces **Homebrew packaging** in-repo via `Formula/tm-exclusions.rb` and documents installation/release workflow across `README.md` and new maintainer docs (`docs/PACKAGING.md`, `docs/DEV_TOOLING.md`, `docs/I18N.md`), plus a `CLAUDE.md` pointer to `AGENTS.md`.
> 
> Updates the CLI’s `detect_language()` to respect `LC_ALL`/`LC_MESSAGES`/`LC_CTYPE` before `LANG`, and extends smoke tests to cover locale-based language selection and `TM_EXCLUSIONS_DEFAULT_CONF` override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d2d87671adc6cee111d8cfdd9e247489c351a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew installation support now available via `brew tap qveys/homebrew-tools && brew install tm-exclusions`
  * Environment variable override for default configuration via `TM_EXCLUSIONS_DEFAULT_CONF`

* **Documentation**
  * Added comprehensive packaging and installation guidance
  * Added internationalization documentation
  * Added developer tooling reference
  * Updated architecture documentation with default rules resolution strategy

* **Tests**
  * Added configuration override smoke test
  * Added version verification test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->